### PR TITLE
Error handling, parted fixes, extra space command line argument

### DIFF
--- a/autosizer.sh
+++ b/autosizer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # Automatic Image file resizer
 # Written by SirLagz
 strImgFile=$1

--- a/autosizer.sh
+++ b/autosizer.sh
@@ -2,6 +2,7 @@
 # Automatic Image file resizer
 # Written by SirLagz
 strImgFile=$1
+extraSpaceMB=$2
 
 if [[ ! $(whoami) =~ "root" ]]; then
 echo ""
@@ -13,8 +14,12 @@ exit
 fi
 
 if [[ -z $1 ]]; then
-echo "Usage: ./autosizer.sh <Image File>"
+echo "Usage: ./autosizer.sh <Image File> [<extra space in MB>]"
 exit
+fi
+
+if [[ -z $2 ]]; then
+extraSpaceMB=4
 fi
 
 if [[ ! -e $1 || ! $(file $1) =~ "x86" ]]; then
@@ -28,12 +33,15 @@ partstart=`echo "$partinfo" | grep ext4 | awk -F: ' { print substr($2,0,length($
 loopback=`losetup -f --show -o $partstart $1`
 e2fsck -f $loopback
 minsize=`resize2fs -P $loopback | awk -F': ' ' { print $2 } '`
-minsize=`echo $minsize+1000 | bc`
+blocksize=$(dumpe2fs -h $loopback | grep 'Block size' | awk -F': ' ' { print $2 }')
+blocksize=${blocksize// /}
+
+let minsize=$minsize+$extraSpaceMB*1048576/$blocksize
 resize2fs -p $loopback $minsize
 sleep 1
 losetup -d $loopback
-partnewsize=`echo "$minsize * 4096" | bc`
-newpartend=`echo "$partstart + $partnewsize" | bc`
+let partnewsize=$minsize*$blocksize
+let newpartend=$partstart+$partnewsize
 part1=`parted -s $1 rm 2`
 part2=`parted -s $1 unit B mkpart primary $partstart $newpartend`
 endresult=`parted -s -m $1 unit B print free | tail -1 | awk -F: ' { print substr($2,0,length($2)-1) } '`

--- a/autosizer.sh
+++ b/autosizer.sh
@@ -22,7 +22,7 @@ echo "Error : Not an image file, or file doesn't exist"
 exit
 fi
 
-partinfo=`parted -m $1 unit B print`
+partinfo=`parted -s -m $1 unit B print`
 partnumber=`echo "$partinfo" | grep ext4 | awk -F: ' { print $1 } '`
 partstart=`echo "$partinfo" | grep ext4 | awk -F: ' { print substr($2,0,length($2)-1) } '`
 loopback=`losetup -f --show -o $partstart $1`
@@ -34,7 +34,7 @@ sleep 1
 losetup -d $loopback
 partnewsize=`echo "$minsize * 4096" | bc`
 newpartend=`echo "$partstart + $partnewsize" | bc`
-part1=`parted $1 rm 2`
-part2=`parted $1 unit B mkpart primary $partstart $newpartend`
-endresult=`parted -m $1 unit B print free | tail -1 | awk -F: ' { print substr($2,0,length($2)-1) } '`
+part1=`parted -s $1 rm 2`
+part2=`parted -s $1 unit B mkpart primary $partstart $newpartend`
+endresult=`parted -s -m $1 unit B print free | tail -1 | awk -F: ' { print substr($2,0,length($2)-1) } '`
 truncate -s $endresult $1


### PR DESCRIPTION
Hi Lawrence, as I mentioned in email, here are the changes that I've made to your script. I hope they are all improvements!

The -s flag in parted was key for me in making parted behave correctly all the time.

The extra space command line argument improves some of the calculations in the script, and I've tried to replicate the previous behaviour of adding 1000 to the minsize by having the default extra space at 4MB. Note that the magic number 1048576 is 1024^2, or the number of bytes in a MB.
